### PR TITLE
Fix remove redundant config file

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,8 @@ cli
 
       // compile
       const swcBin = require.resolve('.bin/swc')
-      const swcArgs = [file, ..._swcArgs, '--config-file', SWCRC_PATH]
+      const cleanedSwcArgs = removeDuplicateConfigFileFromArgs(_swcArgs, configFile)
+      const swcArgs = [file, ...cleanedSwcArgs, '--config-file', SWCRC_PATH]
       if (debug) {
         console.log(`> swc ${swcArgs.join(' ')}`)
       }
@@ -82,6 +83,26 @@ cli
       fs.unlinkSync(SWCRC_PATH)
     }
   })
+
+  /**
+   * Removes the --config-file option and its value from an array of raw swc args
+   * @param swcArgs 
+   * @param configFileArg - the --config-file value argument that you parsed already
+   * @returns 
+   */
+function removeDuplicateConfigFileFromArgs(swcArgs: string[], configFileArg?: string) {
+  let lastArgWasConfigFile = false
+  return configFileArg ? swcArgs.reduce((cleanArgs: string[], arg: string) => {
+    if (arg === '--config-file') {
+      lastArgWasConfigFile = true
+    } else if (lastArgWasConfigFile && arg === configFileArg) {
+      // We don't push anything here because the second arg is also skipped
+    } else {
+      cleanArgs.push(arg)
+    }
+    return cleanArgs
+  }, [] as string[]) : swcArgs
+}
 
 cli.help()
 


### PR DESCRIPTION
# Summary

This is not an impactor right now, but could be in the future.  When debugging the library locally, I realized that we don't remove the --config-file from the args and end up with a call like:

```
swc --config-file .esm.swcrc -d dist --config-file tswcrc
```

To prevent some change in ordering in the CLI library from creating erroneous results, I have added a clean method to the args that we pass in if a configFile was detected.