### PR TITLE
Fix windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x, 22.x]
+        os: [ ubuntu-latest, 'windows-latest' ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +27,6 @@ jobs:
       - name: Verify the command 
         run: |
           node $(jq -r '.bin' package.json) --version
-
 
   publish:
     name: npm-publish

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,8 @@ cli
 
       // compile
       const swcBin = require.resolve('.bin/swc')
-      const swcArgs = [file, ..._swcArgs, '--config-file', SWCRC_PATH]
+      const cleanedSwcArgs = removeDuplicateConfigFileFromArgs(_swcArgs, configFile)
+      const swcArgs = [file, ...cleanedSwcArgs, '--config-file', SWCRC_PATH]
       if (debug) {
         console.log(`> swc ${swcArgs.join(' ')}`)
       }
@@ -82,6 +83,26 @@ cli
       fs.unlinkSync(SWCRC_PATH)
     }
   })
+
+  /**
+   * Removes the --config-file option and its value from an array of raw swc args
+   * @param swcArgs 
+   * @param configFileArg - the --config-file value argument that you parsed already
+   * @returns 
+   */
+function removeDuplicateConfigFileFromArgs(swcArgs: string[], configFileArg?: string) {
+  let lastArgWasConfigFile = false
+  return configFileArg ? swcArgs.reduce((cleanArgs: string[], arg: string) => {
+    if (arg === '--config-file') {
+      lastArgWasConfigFile = true
+    } else if (lastArgWasConfigFile && arg === configFileArg) {
+      // We don't push anything here because the second arg is also skipped
+    } else {
+      cleanArgs.push(arg)
+    }
+    return cleanArgs
+  }, [] as string[]) : swcArgs
+}
 
 cli.help()
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,6 +75,8 @@ cli
         stdio: 'inherit',
         cwd: process.cwd(),
         env: process.env,
+        // Windows does not do spawn well without shell explicitly set
+        shell: process.platform === "win32" ? true : undefined,
       })
     } catch (e) {
       /* istanbul ignore next */

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,16 +2,19 @@ import { describe, it } from 'vitest'
 import path from 'path'
 import { spawnSync } from 'child_process'
 
-const node = './node_modules/.bin/ts-node'
+const node = path.join('.', 'node_modules', '.bin', 'ts-node');
 const cliBin = path.join(__dirname, '..', 'src', 'cli.ts')
 
 // const node = 'node'
 // const cliBin = path.join(__dirname, '..', 'dist', 'cli.js')
 
+const shell = process.platform === 'win32' ? true : undefined;
+
 describe('test suite', () => {
   it('generally works', ({ expect }) => {
     const proc = spawnSync(node, [cliBin], {
       stdio: 'pipe',
+      shell,
     })
     expect(proc.stdout.toString()).toBeTypeOf('string')
     expect(proc.status).toBe(0)
@@ -28,7 +31,7 @@ describe('test suite', () => {
         '--config-file',
         path.join(__dirname, 'fixtures', 'src', '.swcrc'),
       ],
-      { stdio: 'pipe' },
+      { stdio: 'pipe', shell },
     )
     expect(proc.status).toBe(0)
     expect(proc.stderr.toString()).toMatch('')
@@ -41,7 +44,7 @@ describe('test suite', () => {
       node,
       [cliBin, codePath, '--debug', '--tsconfig', 'tsconfig.json'],
       {
-        stdio: 'pipe',
+        stdio: 'pipe', shell,
       },
     )
     expect(proc.status).toBe(0)
@@ -55,7 +58,7 @@ describe('test suite', () => {
         node,
         [cliBin, codePath, '--', '--random-args-for-error'],
         {
-          stdio: 'pipe',
+          stdio: 'pipe', shell,
         },
       )
       expect(proc.status).toBe(1)
@@ -75,7 +78,7 @@ describe('test suite', () => {
           '--config-file',
           path.join(__dirname, 'fixtures', 'src', 'nope.swcrc'),
         ],
-        { stdio: 'pipe' },
+        { stdio: 'pipe', shell },
       )
       expect(proc.status).toBe(1)
       expect(proc.stderr.toString()).toMatch(


### PR DESCRIPTION
# Summary

This adds a consideration to run the spawn process in a shell since from experience, windows doesn't run anything if not set.

Here is the SO that also talks about it. https://stackoverflow.com/questions/37125619/spawnsyncnpm-install-gives-error-spawnsync-npm-enoent